### PR TITLE
nit for readibility

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-A key component of any successful initiative includes establishing productive metrics that encourage productive participation and create accountability. Metrics for Code California will refrain from instilling an atmosphere of compliance, but instead one of community, which is fundamental to a thriving open source ecosystem.
+A key component of any successful initiative includes establishing meaningful metrics that encourage productive participation and create accountability. Metrics for Code California will refrain from instilling an atmosphere of compliance, but instead one of community, which is fundamental to a thriving open source ecosystem.
 
 By deploying a collaborative strategy to agency open source participation, our approach to 2019 metrics encompass those that encourage a culture of education and community, inspiring and connecting the early adopters and government open source champions, who will then serve as the foundation of support to the community as it grows.
 


### PR DESCRIPTION
Changed the phrase "productive metric" to "meaningful metrics" to avoid using the word productive twice in the same sentence.